### PR TITLE
multiselect tweaks

### DIFF
--- a/psetpartners/static/psetpartners.js
+++ b/psetpartners/static/psetpartners.js
@@ -37,7 +37,7 @@ function makeSingleSelect(id, available, config) {
     else if ( evt.which === 37 || evt.which === 38 ) { if ( ! s.prev() ) s.open(); evt.preventDefault(); }
     else if ( evt.which === 27 || evt.which === 33 ) { s.close(); evt.preventDefault(); }
     else if ( evt.which === 34 ) { s.open(); evt.preventDefault(); }
-    else if ( evt.which === 13 ) { s.toggle(); evt.preventDefault(); }
+    else if ( evt.which === 13 ) {  evt.preventDefault(); if ( config.autocomplete ) s.selectone(); else s.toggle(); }
   });
  
   e.value = s.value();
@@ -93,6 +93,7 @@ function makeMultiSelect(id, available, config) {
   se.addEventListener('keydown', function(evt) {
     if ( evt.which == 34 | evt.which === 39 || evt.which === 40 || evt.which === 34 ) { s.open();  evt.preventDefault(); }
     else if ( evt.which == 33 || evt.which === 37 || evt.which === 38 || evt.which === 27 || evt.which == 33 ) { s.close();  evt.preventDefault(); }
+    else if ( evt.which === 13 ) {  evt.preventDefault(); if ( config.autocomplete ) s.selectone(); else s.toggle(); }
   });
   //e.value = s.value();
   jQuery(e).data('select',s);

--- a/psetpartners/static/select-pure.js
+++ b/psetpartners/static/select-pure.js
@@ -109,6 +109,7 @@ class SelectPure {
   next() { return this._next(); }
   prev() { return this._prev(); }
   notes(v) { if ( v !== undefined ) { this._setNotes(v); } else return this._getNotes(); }
+  selectone() { return this._selectone(); }
 
   // Private methods
   _create(_element) {
@@ -225,6 +226,17 @@ class SelectPure {
     for ( i-- ; i >= 0 && (this._config.options[i].disabled || this._options[i].get().classList.contains(this._config.classNames.optionHidden)) ; i-- );
     if ( i < 0 ) return false;
     this._setValue(this._config.options[i].value);
+    return true;
+  }
+
+  _selectone() {
+    var _option = null;
+    for ( let i = 0 ; i < this._config.options.length ; i++ ) {
+      if ( this._config.options[i].disabled || this._options[i].get().classList.contains(this._config.classNames.optionHidden) ) continue;
+      if ( _option ) return false;
+      _option = this._options[i];
+    }
+    _option.click();
     return true;
   }
 

--- a/psetpartners/static/select-pure.js
+++ b/psetpartners/static/select-pure.js
@@ -230,13 +230,17 @@ class SelectPure {
   }
 
   _selectone() {
+    if ( ! this._autocomplete ) return false;
+    if ( ! this._state.opened ) { this._open(); return false; }
     var _option = null;
     for ( let i = 0 ; i < this._config.options.length ; i++ ) {
       if ( this._config.options[i].disabled || this._options[i].get().classList.contains(this._config.classNames.optionHidden) ) continue;
       if ( _option ) return false;
       _option = this._options[i];
     }
-    _option.click();
+    _option.get().click();
+    this._match('');
+    if ( ! this._config.multiple || this._config.value.length >= this._config.limit ) this._close();
     return true;
   }
 

--- a/psetpartners/templates/student.html
+++ b/psetpartners/templates/student.html
@@ -899,7 +899,7 @@ document.addEventListener('DOMContentLoaded', function() {
 
   makeMultiSelect('departments', 
     studentOptions.departments,
-    { placeholder: studentPlaceholders.departments, limit: maxlength.departments, onLimit: departmentsLimit}
+    { placeholder: studentPlaceholders.departments, limit: maxlength.departments,  autocomplete: true, onLimit: departmentsLimit}
   );
   makeMultiSelect('classes',
     classesOptions,


### PR DESCRIPTION
multiselects with autocomplete will now select the single matching option (if exactly one matches) when you press enter.  This makes it possible to enter all your classes entirely from the keyboard by simply typing your class numbers and pressing enter after each one.  I added autocomplete to the department selector to make this functionality available there as well (the number of options isn't that large but being able to pick them entirely from the keyboard makes it worth doing).