### PR TITLE
append psycodict path

### DIFF
--- a/psetpartners/__init__.py
+++ b/psetpartners/__init__.py
@@ -1,6 +1,8 @@
 # -*- coding: utf-8 -*-
 
 __version__ = "0.0"
+import os
+import sys
 # append psycodict path to the import path, to use the submodule
 sys.path.append(os.path.join(os.path.dirname(os.path.abspath(__file__)), "../psycodict"))
 from psycodict.database import PostgresDatabase

--- a/psetpartners/__init__.py
+++ b/psetpartners/__init__.py
@@ -1,7 +1,8 @@
 # -*- coding: utf-8 -*-
 
 __version__ = "0.0"
-
+# append psycodict path to the import path, to use the submodule
+sys.path.append(os.path.join(os.path.dirname(os.path.abspath(__file__)), "../psycodict"))
 from psycodict.database import PostgresDatabase
 from .config import Configuration
 config = Configuration()


### PR DESCRIPTION
Without appending the path, python will try to import the system psycodict instead of the submodule